### PR TITLE
Inline cast fetch in App useEffect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,14 +13,14 @@ function App() {
   let [cast, setCast] = useState([]);
   let [memberInfo, setMemberInfo] = useState(null);
 
-  async function fetchCast() {
-    const response = await fetch('cast.json');
-    setCast(await response.json());
-  }
-
   useEffect(() => {
-    fetchCast();
-  });
+    const loadCast = async () => {
+      const response = await fetch('cast.json');
+      setCast(await response.json());
+    };
+
+    loadCast();
+  }, []);
 
   return (
     <div className="container">


### PR DESCRIPTION
## Summary
- inline the cast fetch logic directly inside the `useEffect`
- ensure the effect only runs once on mount by providing an empty dependency array

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f2e0c88483298fdb68118aa27f4a